### PR TITLE
FIX: rds-download-db-logfile ignores AWS_DEFAULT_REGION

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -20,6 +20,7 @@ downloaded_files = files.last(log_file_count).map do |file|
                "--db-instance-identifier", ENV['DB_INSTANCE_IDENTIFIER'],
                "-I", ENV['AWS_ACCESS_KEY_ID'],
                "-S", ENV['AWS_SECRET_ACCESS_KEY'],
+               "--region", ENV['AWS_DEFAULT_REGION'],
                "--log-file-name", file[:log_file_name]]
 
     puts file[:log_file_name]


### PR DESCRIPTION
Hi

I've tested your container on `eu-west-1` region and it failed to download rds log files because `rds-download-db-logfile` reads region from `EC2_REGION`.